### PR TITLE
2021.10.04-HMW-Added updates to GitPod config files

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,3 +5,4 @@ image:
 vscode:
   extensions:
     - https://github.com/hpcc-systems/vscode-ecl/releases/latest/download/hpcc-systems.ecl.vsix
+    - https://github.com/GordonSmith/vscode-ojs/releases/latest/download/gordonsmith.observable-js.vsix


### PR DESCRIPTION
The latest ECL Extension for VS Code can show results from non https environments when hosted on gitpod.